### PR TITLE
fix improper looping when no detections available.

### DIFF
--- a/threats-monitoring/trellix_edr_threats.py
+++ b/threats-monitoring/trellix_edr_threats.py
@@ -192,6 +192,7 @@ class EDR():
 
                     else:
                         logger.debug('No new threats identified. Exiting. {0}'.format(res))
+                        tnextflag = False # line added to allow loop to finish successfully and cause loop to immediately repeat and bypass the retry interval.
                 elif res.status_code==429:
                      retry_interval=self.get_retryinterval(res)
                      logger.debug('Rate Limit Exceed in Threats Api, retrying after  {} sec'.format(retry_interval))


### PR DESCRIPTION
An issue was observed in my lab environment where if no detections were available, get_threats would immediately loop, and not recognise the retry interval. Adding this line now allows the loop in get_threats to finish successfully, and the while loop at the end of the script to be reached, and the retry interval to be respected. This seems to have fixed the issue in my lab, so thought a PR might help. Thanks!